### PR TITLE
Update count script 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are interested in becoming a developer, see `docs/developers.md`.
 
 To run Mirrulations, you need Python 3.9 or greater ([MacOSX](https://docs.python-guide.org/starting/install3/osx/) or [Windows](https://docs.python-guide.org/starting/install3/win/)) on your machine to run this, as well as [redis](https://redis.io/) if you are running a server
 
-You will also need a valid API key from Regulations.gov to participate. To apply for a key, you must simply [contact the Regulations Help Desk](regulations@erulemakinghelpdesk.com) and provide your name, email address, organization, and intended use of the API. If you are not with any organizations, just say so in your message. They will email you with a key once they've verified you and activated the key.
+You will also need a valid API key from Regulations.gov to participate. To apply for a key, you must simply complete the API key request form (https://open.gsa.gov/api/regulationsgov/) and provide your name, email address, organization, and intended use of the API. After review the key will be sent by email.
 
 To download the actual project, you will need to go to our [GitHub page](https://github.com/MoravianUniversity/mirrulations) and [clone](https://help.github.com/articles/cloning-a-repository/) the project to your computer.
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -10,3 +10,18 @@ The goal is
 that the client will request and complete work in order to download data from 
 [regulations.gov](https://www.regulations.gov/).
 
+## Attributes 
+api_key: Used to authenticate requests made to the API.
+client_id: An ID included in the client.env file.
+path_generator: An instance of PathGenerator that returns a path for saving job results.
+saver: An instance of Saver that handles saving files either to disk or Amazon S3.
+redis: A connection to the Redis server for managing job states.
+job_queue: A queue from which the client pulls jobs.
+cache: An instance of JobStatistics for caching job statistics.
+
+## Workflow 
+Initialization: The Client is initialized with a Redis server and a job queue.
+Fetching Jobs: The client attempts to fetch a job from the job queue using _get_job_from_job_queue.
+Performing Jobs: Depending on the job type, the client performs the job by calling an API endpoint to request a JSON object.
+Saving Results: The client saves the job results and any included attachments using the Saver class.
+Updating Redis: The client updates the Redis server with job states.

--- a/docs/database.md
+++ b/docs/database.md
@@ -12,29 +12,23 @@ regulations_total_comments
 num_dockets_done
 num_documents_done
 num_attachments_done
-num_jobs_num_jobs_documents_queue_queue
-num_pdf_attachment_done
-num_jobs_num_jobs_dockets_queue_queue
 last_job_id
 jobs_in_progress
 num_pdf_attachments_done
 num_jobs_documents_waiting
 num_jobs_comments_waiting
 dockets_last_timestamp
-num_jobs_num_jobs_comments_queue_queue
 invalid_jobs
 regulations_total_dockets
 client_jobs
-last_timestamp
-total_num_client_ids
 num_extractions_done
 regulations_total_documents
 mirrulations_bucket_size
 num_comments_done
-num_jobs_attachments_waiting
 documents_last_timestamp
 num_jobs_dockets_waiting
 comments_last_timestamp
+
 
 ## Job Management
 
@@ -90,10 +84,6 @@ timestamp seen when querying regulations.gov.
 The `last_job_id` variable is used by the work generator to ensure it generates
 unique ids for each job.
 
-## Client IDs
-
-The 'last_client_id' variable is used by the work server to ensure that it
-generates unique client ids.
 
 ## Job Statistics Keys 
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -2,8 +2,39 @@
 
 ## Database Format
 
-We use [Redis](https://redis.io/) to store jobs as well as key values that must
-be remembered.
+We use [Redis](https://redis.io/) to store jobs as well as key values 
+
+## Database Structure 
+
+The Redis database is structured with the following keys: 
+
+regulations_total_comments
+num_dockets_done
+num_documents_done
+num_attachments_done
+num_jobs_num_jobs_documents_queue_queue
+num_pdf_attachment_done
+num_jobs_num_jobs_dockets_queue_queue
+last_job_id
+jobs_in_progress
+num_pdf_attachments_done
+num_jobs_documents_waiting
+num_jobs_comments_waiting
+dockets_last_timestamp
+num_jobs_num_jobs_comments_queue_queue
+invalid_jobs
+regulations_total_dockets
+client_jobs
+last_timestamp
+total_num_client_ids
+num_extractions_done
+regulations_total_documents
+mirrulations_bucket_size
+num_comments_done
+num_jobs_attachments_waiting
+documents_last_timestamp
+num_jobs_dockets_waiting
+comments_last_timestamp
 
 ## Job Management
 
@@ -11,14 +42,19 @@ The REDIS database has three "queues", with the names:
 
 `jobs_waiting_queue`, `jobs_in_progress`, and `jobs_done`.
 
-`jobs_waiting_queue` is a list, while 'jobs_in_progress' and 'jobs_done' are hashes.
-Each stores jobs for clients to process.
+The keys serve the following functions: 
 
-Keys will be integers, the job ids of the jobs.
-These keys will be mapped to integers, the values to be processed.
+jobs_waiting_queue: A list holding JSON strings representing each job.
 
-Additionally, the database has an integer value storing the number of clients:
-`total_num_client_ids`.
+jobs_in_progress: A hash storing jobs currently being processed.
+
+jobs_done: A hash storing completed jobs.
+
+The keys client_jobs and total_num_client_ids are used for sotring client information.
+
+client_jobs: A hash mapping job IDs to client IDs.
+
+total_num_client_ids: An integer value storing the number of clients.
 
 ## Redis Format
 ## `jobs_waiting_queue`
@@ -58,3 +94,19 @@ unique ids for each job.
 
 The 'last_client_id' variable is used by the work server to ensure that it
 generates unique client ids.
+
+## Job Statistics Keys 
+
+DOCKETS_DONE: Tracks the number of completed dockets.
+
+DOCUMENTS_DONE: Tracks the number of completed documents.
+
+COMMENTS_DONE: Tracks the number of completed comments.
+
+ATTACHMENTS_DONE: Tracks the number of completed attachments.
+
+PDF_ATTACHMENTS_DONE: Tracks the number of completed PDF attachments.
+
+EXTRACTIONS_DONE: Tracks the number of completed extractions.
+
+MIRRULATION_BUCKET_SIZE: Stores the size of the mirrulations bucket.

--- a/scripts/update_counts.py
+++ b/scripts/update_counts.py
@@ -1,0 +1,87 @@
+import argparse
+import json
+import redis
+import sys
+
+def list_current_values(r):
+    keys = [
+        "num_dockets_done",
+        "num_documents_done",
+        "num_comments_done",
+        "dockets_last_timestamp",
+        "documents_last_timestamp",
+        "comments_last_timestamp"
+    ]
+    print("Current Redis Key Values:")
+    print("-" * 50)
+    for key in keys:
+        value = r.get(key)
+        value = value.decode('utf-8') if value else 'None'
+        print(f"{key}: {value}")
+    print("-" * 50)
+
+def update_values(r, data):
+    # Extract values from JSON data
+    num_dockets_done = data.get("dockets", {}).get("downloaded", 0)
+    num_documents_done = data.get("documents", {}).get("downloaded", 0)
+    num_comments_done = data.get("comments", {}).get("downloaded", 0)
+    stop_timestamp = data.get("stop_timestamp", "")
+    
+    # Mapping from Redis keys to values
+    key_value_pairs = {
+        "num_dockets_done": num_dockets_done,
+        "num_documents_done": num_documents_done,
+        "num_comments_done": num_comments_done,
+        "dockets_last_timestamp": stop_timestamp,
+        "documents_last_timestamp": stop_timestamp,
+        "comments_last_timestamp": stop_timestamp
+    }
+
+    # Display current and new values
+    print("Current and New Values:")
+    print("-" * 50)
+    for key, new_value in key_value_pairs.items():
+        current_value = r.get(key)
+        current_value = current_value.decode('utf-8') if current_value else 'None'
+        print(f"Key: {key}")
+        print(f"Current Value: {current_value}")
+        print(f"New Value: {new_value}")
+        print("-" * 50)
+
+    # Confirm before updating
+    confirm = input("Do you want to update these keys with the new values? (yes/no): ").strip().lower()
+    if confirm == 'yes':
+        for key, new_value in key_value_pairs.items():
+            r.set(key, new_value)
+        print("Keys have been updated successfully.")
+    else:
+        print("No changes have been made.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Redis Key Updater")
+    parser.add_argument('-i', '--input', help='Path to the JSON file')
+    args = parser.parse_args()
+
+    # Connect to Redis
+    try:
+        r = redis.Redis(host='localhost', port=6379, db=0)
+        r.ping()
+    except redis.exceptions.ConnectionError as e:
+        print(f"Error connecting to Redis: {e}")
+        sys.exit(1)
+
+    if args.input:
+        # Load JSON data from the provided file
+        try:
+            with open(args.input, 'r') as f:
+                data = json.load(f)
+        except Exception as e:
+            print(f"Error reading JSON file: {e}")
+            sys.exit(1)
+        update_values(r, data)
+    else:
+        # List current values
+        list_current_values(r)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR contains the update_count script which can be used in tandem with the get_counts script to manually update the redis DB with values from the JSON file. The -i flag should be used with a path to the JSON file. The current DB counts and timestamps will be displayed if no file is provided. 